### PR TITLE
Add a check for empty message

### DIFF
--- a/C2_Profiles/basic_webhook/my_webhooks/new_alert.go
+++ b/C2_Profiles/basic_webhook/my_webhooks/new_alert.go
@@ -16,6 +16,14 @@ func newAlertMessage(input webhookstructs.NewAlertWebhookMessage) {
 	newMessage := webhookstructs.GetNewDefaultWebhookMessage()
 	newMessage.Channel = webhookstructs.AllWebhookData.Get("my_webhooks").GetWebhookChannel(input, webhookstructs.WEBHOOK_TYPE_NEW_ALERT)
 	var webhookURL = webhookstructs.AllWebhookData.Get("my_webhooks").GetWebhookURL(input, webhookstructs.WEBHOOK_TYPE_NEW_ALERT)
+	// debug incoming webhookdata
+	fmt.Printf("DEBUG: Received Webhook Data: %+v\n", input)
+
+    if input.Data.Message == "" {
+        logging.LogInfo("Skipping webhook: No message content found in alert.")
+        return
+    }
+
 	if time.Now().Sub(newAlertLastTime).Abs() <= throttleTime {
 		logging.LogInfo("Not sending basic_webhook because <10s has passed since last message")
 		return


### PR DESCRIPTION
Add a check for empty input message, as I kept getting empty webhooks messages, such as this:
```
New Event Alert!
Source: 
```

Added a check to see if the event message is empty, if it is - ignore it.